### PR TITLE
Fix panic

### DIFF
--- a/property/changeset.go
+++ b/property/changeset.go
@@ -25,7 +25,12 @@ func (set *ChangeSet[T]) EnsureDesired(logger logr.Logger) bool {
 	}
 
 	logger.V(1).Info("differences detected", "path", set.path, "diff", cmp.Diff(set.current, set.desired))
-	*set.current = *set.desired
+	if set.desired == nil {
+		set.current = nil
+	} else {
+		*set.current = *set.desired
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Fix panic when some resource's desired stated does not specify some property that the controller is trying to reconcile.
With saas-operator we set default values for everything so I did not catch this until I tried it with marin3r.

/kind bug
/priority important-soon
/assign