### PR TITLE
feat/dynamic-watches

### DIFF
--- a/config/global.go
+++ b/config/global.go
@@ -17,10 +17,12 @@ type ReconcileConfigForGVK struct {
 var config = struct {
 	annotationsDomain              string
 	resourcePruner                 bool
+	dynamicWatches                 bool
 	defaultResourceReconcileConfig map[string]ReconcileConfigForGVK
 }{
 	annotationsDomain: "basereconciler.3cale.net",
 	resourcePruner:    true,
+	dynamicWatches:    true,
 	defaultResourceReconcileConfig: map[string]ReconcileConfigForGVK{
 		"*": {
 			EnsureProperties: []string{
@@ -55,6 +57,17 @@ func DisableResourcePruner() { config.resourcePruner = false }
 
 // IsResourcePrunerEnabled returs a boolean indicating wheter the resource pruner is enabled or not.
 func IsResourcePrunerEnabled() bool { return config.resourcePruner }
+
+// EnableDynamicWatches enables controller dynamic watches. Dynamic watches keep track of the resource
+// types that the controller owns and dynamically adds watches to the controller for those.
+func EnableDynamicWatches() { config.dynamicWatches = true }
+
+// DisableDynamicWatches disables controller dynamic watches. Dynamic watches keep track of the resource
+// types that the controller owns and dynamically adds watches to the controller for those.
+func DisableDynamicWatches() { config.dynamicWatches = false }
+
+// AreDynamicWatchesEnabled returs a boolean indicating wheter the dynamic watches are enabled or not.
+func AreDynamicWatchesEnabled() bool { return config.dynamicWatches }
 
 // GetDefaultReconcileConfigForGVK returns the default configuration that instructs basereconciler how to reconcile
 // a given kubernetes GVK (GroupVersionKind). This default config will be used if the "resource.Template" object (see

--- a/mutators/mutators.go
+++ b/mutators/mutators.go
@@ -50,7 +50,7 @@ func SetDeploymentReplicas(enforce bool) resource.TemplateMutationFunction {
 
 // SetServiceLiveValues retrieves some live values of the Service spec from the Kubernetes
 // API to avoid overwriting them. These values are typically set the by the kube-controller-manager
-// (in some rare occasions the user might explicitely set them) and should not be modified by the
+// (in some rare occasions the user might explicitly set them) and should not be modified by the
 // reconciler. The fields that this function keeps in sync with the live state are:
 //   - spec.clusterIP
 //   - spec.ClisterIPs

--- a/reconciler/pruner.go
+++ b/reconciler/pruner.go
@@ -3,16 +3,13 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
-	"sync"
 
 	"github.com/3scale-ops/basereconciler/config"
 	"github.com/3scale-ops/basereconciler/util"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -71,19 +68,4 @@ func isPrunerEnabled(owner client.Object) bool {
 		}
 	}
 	return prune && config.IsResourcePrunerEnabled()
-}
-
-type typeTracker struct {
-	seenTypes []schema.GroupVersionKind
-	mu        sync.Mutex
-}
-
-func (tt *typeTracker) trackType(gvk schema.GroupVersionKind) {
-	if !util.ContainsBy(tt.seenTypes, func(x schema.GroupVersionKind) bool {
-		return reflect.DeepEqual(x, gvk)
-	}) {
-		tt.mu.Lock()
-		defer tt.mu.Unlock()
-		tt.seenTypes = append(tt.seenTypes, gvk)
-	}
 }

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/3scale-ops/basereconciler/config"
 	"github.com/3scale-ops/basereconciler/resource"
 	"github.com/3scale-ops/basereconciler/util"
 	"github.com/go-logr/logr"
@@ -298,7 +299,7 @@ func (r *Reconciler) ReconcileOwnedResources(ctx context.Context, owner client.O
 		if ref != nil {
 			managedResources = append(managedResources, *ref)
 			gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
-			if changed := r.typeTracker.trackType(gvk); changed {
+			if changed := r.typeTracker.trackType(gvk); changed && config.AreDynamicWatchesEnabled() {
 				r.watchOwned(gvk, owner)
 				// requeue so we make sure we haven't lost any events related to the owned resource
 				// while the watch was not still up

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -253,7 +253,7 @@ func (r *Reconciler) isInitialized(ctx context.Context, obj client.Object, fns [
 // inMemoryInitialization can be used to perform initializarion on the resource that is not
 // persisted in the API storage. This can be used to perform initialization on the resource without
 // writing it to the API to avoid surfacing it uo to the user. This approach is a bit more
-// gitops firendly as it avoids modifying the resource, but it doesn't provide any information
+// gitops friendly as it avoids modifying the resource, but it doesn't provide any information
 // to the user on the initialization being used for reconciliation.
 func (r *Reconciler) inMemoryInitialization(ctx context.Context, obj client.Object, fns []inMemoryinitializationFunction) error {
 	for _, fn := range fns {
@@ -286,7 +286,7 @@ func (r *Reconciler) finalize(ctx context.Context, fns []finalizationFunction, l
 //   - Each template is added to the list of managed resources if resource.CreateOrUpdate returns with no error
 //   - If the resource pruner is enabled any resource owned by the custom resource not present in the list of managed
 //     resources is deleted. The resource pruner must be enabled in the global config (see package config) and also not
-//     explicitely disabled in the resource by the '<annotations-domain>/prune: true/false' annotation.
+//     explicitly disabled in the resource by the '<annotations-domain>/prune: true/false' annotation.
 func (r *Reconciler) ReconcileOwnedResources(ctx context.Context, owner client.Object, list []resource.TemplateInterface) Result {
 	managedResources := []corev1.ObjectReference{}
 	requeue := false

--- a/reconciler/tracker.go
+++ b/reconciler/tracker.go
@@ -1,0 +1,69 @@
+package reconciler
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/3scale-ops/basereconciler/util"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type ReconcilerWithTypeTracker interface {
+	reconcile.Reconciler
+	BuildTypeTracker(ctrl controller.Controller)
+}
+
+func SetupWithDynamicTypeWatches(r ReconcilerWithTypeTracker, bldr *builder.Builder) error {
+	ctrl, err := bldr.Build(r)
+	if err != nil {
+		return err
+	}
+	r.BuildTypeTracker(ctrl)
+	return nil
+}
+
+type typeTracker struct {
+	seenTypes []schema.GroupVersionKind
+	ctrl      controller.Controller
+	mu        sync.Mutex
+}
+
+func (tt *typeTracker) trackType(gvk schema.GroupVersionKind) bool {
+	if !util.ContainsBy(tt.seenTypes, func(x schema.GroupVersionKind) bool {
+		return reflect.DeepEqual(x, gvk)
+	}) {
+		tt.mu.Lock()
+		defer tt.mu.Unlock()
+		tt.seenTypes = append(tt.seenTypes, gvk)
+		return true
+	}
+	return false
+}
+
+func (r *Reconciler) watchOwned(gvk schema.GroupVersionKind, owner client.Object) error {
+	o, err := util.NewObjectFromGVK(gvk, r.Scheme)
+	if err != nil {
+		return err
+	}
+	r.typeTracker.mu.Lock()
+	defer r.typeTracker.mu.Unlock()
+	err = r.typeTracker.ctrl.Watch(&source.Kind{Type: o}, &handler.EnqueueRequestForOwner{OwnerType: owner, IsController: true})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Reconciler is expected to be overwriten
+func (r *Reconciler) BuildTypeTracker(ctrl controller.Controller) {
+	r.typeTracker = typeTracker{
+		seenTypes: []schema.GroupVersionKind{},
+		ctrl:      ctrl,
+	}
+}

--- a/reconciler/tracker.go
+++ b/reconciler/tracker.go
@@ -14,11 +14,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+// ReconcilerWithTypeTracker is a reconciler with a TypeTracker
+// The type tracker is used by the "resource pruner" and "dynamic watches"
+// features
 type ReconcilerWithTypeTracker interface {
 	reconcile.Reconciler
 	BuildTypeTracker(ctrl controller.Controller)
 }
 
+// SetupWithDynamicTypeWatches is a helper to build a controller that can watch resource
+// types dynamically. It is typically used within the "SetupWithManager" function.
+// Example usage:
+//
+//	func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+//		return reconciler.SetupWithDynamicTypeWatches(r,
+//			ctrl.NewControllerManagedBy(mgr).
+//				For(&v1alpha1.Test{}).
+//	            // add any other watches here
+//				Watches(...}.Watches(...),
+//		)
+//	}
 func SetupWithDynamicTypeWatches(r ReconcilerWithTypeTracker, bldr *builder.Builder) error {
 	ctrl, err := bldr.Build(r)
 	if err != nil {
@@ -60,7 +75,8 @@ func (r *Reconciler) watchOwned(gvk schema.GroupVersionKind, owner client.Object
 	return nil
 }
 
-// Reconciler is expected to be overwriten
+// BuildTypeTracker passes the controller to the reconciler so watches
+// can be added dynamically
 func (r *Reconciler) BuildTypeTracker(ctrl controller.Controller) {
 	r.typeTracker = typeTracker{
 		seenTypes: []schema.GroupVersionKind{},

--- a/resource/create_or_update.go
+++ b/resource/create_or_update.go
@@ -30,7 +30,7 @@ import (
 //   - owner: the object that owns the resource. Used to set the OwnerReference in the resource
 //   - template: the struct that describes how the resource needs to be reconciled. It must implement
 //     the TemplateInterface interface. When template.GetEnsureProperties is not set or an empty list, this
-//     function will lookup for configuration in the global configuration (see pacakge config).
+//     function will lookup for configuration in the global configuration (see package config).
 func CreateOrUpdate(ctx context.Context, cl client.Client, scheme *runtime.Scheme,
 	owner client.Object, template TemplateInterface) (*corev1.ObjectReference, error) {
 

--- a/resource/doc.go
+++ b/resource/doc.go
@@ -1,0 +1,3 @@
+// Package resource contains types and methods to reconcile controller owned resources
+// It is generalized to work with any GroupVersionKind.
+package resource

--- a/resource/template.go
+++ b/resource/template.go
@@ -37,7 +37,7 @@ type Template[T client.Object] struct {
 	// TemplateBuilder has been invoked, to perform mutations on the object that require
 	// access to a kubernetes API server.
 	TemplateMutations []TemplateMutationFunction
-	// IsEnabled specifies whether the resourse described by this Template should
+	// IsEnabled specifies whether the resource described by this Template should
 	// exist or not.
 	IsEnabled bool
 	// EnsureProperties are the properties from the desired object that should be enforced

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,0 +1,2 @@
+// Package test contains a test controller with its test suite
+package test

--- a/util/doc.go
+++ b/util/doc.go
@@ -1,0 +1,2 @@
+// Package util contains utility functions used by other packages
+package util


### PR DESCRIPTION
Adds the ability to watch the controller owned resources automatically and dynamically once the controller is already started.
The idea is that the type tracker, that was already implemented and was being used for the resource pruner, now also sets up a new watch each time it sees a new resource type (GVK) being managed by the controller.

Pros:
* Only watch for the APIs that the controller is actually using. Useful if the controller has optional dependencies on other APIs as avoids the requirement of always installing them in the cluster

Cons:
* controller-runtime does not provide currently a way of removing a watch from a controller. In the case an API is no longer of interest to the controller it will continue watching it. The workaround is to recreate the controller pod. There's work in progress to provide this capability in controller-runtime: https://github.com/kubernetes-sigs/controller-runtime/pull/2159.

I have also added some missing documentation and fixed several misspells.

/kind feature
/kind documentation
/assign
/priority important-soon