### PR TITLE
Update gh workflow cache version since v2 will be deprecated on Feb 1st 2025

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,17 +20,6 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
-      - uses: actions/cache@v4
-        with:
-          path: ./testbin
-          key: ${{ runner.os }}-testbin
-
-      - uses: actions/cache@v4
-        with:
           path: ./bin
           key: ${{ runner.os }}-bin
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,18 +18,18 @@ jobs:
         with:
           go-version: "1.20"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ./testbin
           key: ${{ runner.os }}-testbin
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ./bin
           key: ${{ runner.os }}-bin

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ GOBINDATA ?= $(LOCALBIN)/go-bindata
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GINKGO_VERSION ?= v2.14.0
-ENVTEST_VERSION ?= latest
+ENVTEST_VERSION ?= release-0.17
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Starting February 1st, 2025, GitHub is closing down v1-v2 of [actions/cache](https://app.github.media/e/er?s=88570519&lid=6814&elqTrackId=a3bc821626b94473987e2c1b05d7f97a&elq=cf7ecc37d391479aba0bbc375df34be7&elqaid=4282&elqat=1&elqak=8AF5A5B4BDB0473BC910C050E532EFF4973977B2FFF7F46FFBAAA7C96B6CF1EC4CA0) (read more about it in this [changelog announcement](https://app.github.media/e/er?s=88570519&lid=6815&elqTrackId=08a5e2ee0de44b669cfee44c72a218f2&elq=cf7ecc37d391479aba0bbc375df34be7&elqaid=4282&elqat=1&elqak=8AF5E7AAA12E3C7C230E5849DC6FF5707A5077B2FFF7F46FFBAAA7C96B6CF1EC4CA0)) as well as all previous versions of the [@actions/cache package](https://app.github.media/e/er?s=88570519&lid=6813&elqTrackId=50ac21f35d544fc981a1f6fc17691756&elq=cf7ecc37d391479aba0bbc375df34be7&elqaid=4282&elqat=1&elqak=8AF5661E2DAA849B548228AA9931C3126C9C77B2FFF7F46FFBAAA7C96B6CF1EC4CA0) in [actions/toolkit](https://app.github.media/e/er?s=88570519&lid=6812&elqTrackId=0b5c70fcb33e4fa3b6eba9d55dbd4f27&elq=cf7ecc37d391479aba0bbc375df34be7&elqaid=4282&elqat=1&elqak=8AF533B9911C7B652C3AE6F25753FAAFE7CE77B2FFF7F46FFBAAA7C96B6CF1EC4CA0). Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure.

This PR updates _cache_ action to generic `v4` version.

/kind feature
/priority important-soon
/assign