### PR TITLE
feat: centralize scheme configuration via runtimeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,13 @@ template := resource.NewTemplateFromObjectFunction(func() *appsv1.Deployment {
 Set a global default scheme to avoid passing it to every constructor:
 
 ```go
-import myscheme "github.com/myorg/myoperator/pkg/scheme"
+import (
+    myscheme "github.com/myorg/myoperator/pkg/scheme"
+    "github.com/3scale-sre/basereconciler/runtimeconfig"
+)
 
 func init() {
-    resource.Scheme = myscheme.Scheme  // Now used by default for all templates
+    runtimeconfig.SetDefaultScheme(myscheme.Scheme)  // Now used by default for all templates
 }
 ```
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/3scale-sre/basereconciler/config"
 	"github.com/3scale-sre/basereconciler/resource"
+	"github.com/3scale-sre/basereconciler/runtimeconfig"
 	"github.com/3scale-sre/basereconciler/util"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -136,6 +137,7 @@ type Reconciler struct {
 
 // NewFromManager returns a new Reconciler from a controller-runtime manager.Manager
 func NewFromManager(mgr manager.Manager) *Reconciler {
+	runtimeconfig.EnsureDefaultScheme(mgr.GetScheme())
 	return &Reconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Log: logr.Discard(), mgr: mgr}
 }
 

--- a/resource/doc.go
+++ b/resource/doc.go
@@ -165,14 +165,17 @@
 //
 // # Scheme Management
 //
-// The package provides a convenient default scheme (resource.Scheme) that is used for GVK inference
-// when no explicit scheme is provided to template constructors. This defaults to the standard
-// Kubernetes scheme but can be overridden globally:
+// The package uses a convenient shared default scheme, managed by the runtimeconfig package, for
+// GVK inference when no explicit scheme is provided to template constructors. This defaults to the
+// standard Kubernetes scheme but can be overridden globally:
 //
-//	import myscheme "github.com/myorg/myoperator/pkg/scheme"
+//	import (
+//	    myscheme "github.com/myorg/myoperator/pkg/scheme"
+//	    "github.com/3scale-sre/basereconciler/runtimeconfig"
+//	)
 //
 //	func init() {
-//		resource.Scheme = myscheme.Scheme
+//		runtimeconfig.SetDefaultScheme(myscheme.Scheme)
 //	}
 //
 // This eliminates the need to pass scheme parameters to every template constructor while still
@@ -204,7 +207,7 @@
 //	import myscheme "github.com/myorg/myoperator/pkg/scheme"
 //
 //	func init() {
-//		resource.Scheme = myscheme.Scheme  // Now all templates use this by default
+//		runtimeconfig.SetDefaultScheme(myscheme.Scheme)  // Now all templates use this by default
 //	}
 //
 // Reconcile Resource (operation type determined by template configuration):
@@ -213,8 +216,8 @@
 //
 // # Advanced Features
 //
-// Default Scheme Management: Global default scheme (resource.Scheme) eliminates the need
-// to pass scheme parameters to every constructor while still allowing per-call overrides.
+// Default Scheme Management: Global default scheme via runtimeconfig eliminates the need to pass
+// scheme parameters to every constructor while still allowing per-call overrides.
 //
 // Automatic GVK Inference: Templates automatically determine their resource type from
 // the generic type parameter, reducing boilerplate and preventing mismatches.

--- a/resource/scheme.go
+++ b/resource/scheme.go
@@ -1,49 +1,13 @@
 package resource
 
 import (
+	"github.com/3scale-sre/basereconciler/runtimeconfig"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
-// Scheme is the default runtime scheme used for GVK inference when no explicit scheme is provided
-// to template constructors (NewTemplate, NewTemplateFromObjectFunction) or other functions that
-// require scheme information.
-//
-// By default, this is set to the standard Kubernetes scheme (scheme.Scheme from client-go) which
-// includes all core Kubernetes types (Pod, Service, Deployment, etc.).
-//
-// Users can override this globally to include custom resources or use a different scheme:
-//
-//	import myscheme "github.com/myorg/myoperator/pkg/scheme"
-//
-//	func init() {
-//		resource.Scheme = myscheme.Scheme
-//	}
-//
-// This provides a convenient way to avoid passing the scheme parameter to every template constructor
-// while still allowing per-call overrides when needed.
-var Scheme *runtime.Scheme = scheme.Scheme
-
 // GetScheme returns the appropriate runtime scheme to use for GVK inference and other operations.
-// If explicit schemes are provided, it returns the first one. Otherwise, it returns the package
-// default scheme (resource.Scheme).
-//
-// This function is used internally by template constructors and other functions that need scheme
-// access, providing a consistent way to handle both explicit and default scheme scenarios.
-//
-// Examples:
-//
-//	// Uses the default scheme (resource.Scheme)
-//	scheme := GetScheme()
-//
-//	// Uses the provided scheme, ignoring the default
-//	scheme := GetScheme(myCustomScheme)
-//
-//	// Multiple schemes provided, uses the first one
-//	scheme := GetScheme(scheme1, scheme2) // Returns scheme1
+// If explicit schemes are provided, it returns the first one. Otherwise, it returns the shared
+// default scheme managed by the runtimeconfig package.
 func GetScheme(s ...*runtime.Scheme) *runtime.Scheme {
-	if len(s) > 0 {
-		return s[0]
-	}
-	return Scheme
+	return runtimeconfig.SelectScheme(s...)
 }

--- a/runtimeconfig/scheme.go
+++ b/runtimeconfig/scheme.go
@@ -1,0 +1,58 @@
+package runtimeconfig
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	schemeMu      sync.RWMutex
+	defaultScheme *runtime.Scheme = clientgoscheme.Scheme
+	schemeFrozen  bool
+)
+
+// DefaultScheme returns the current shared runtime scheme used across the basereconciler
+// packages. It is safe for concurrent use.
+func DefaultScheme() *runtime.Scheme {
+	schemeMu.RLock()
+	defer schemeMu.RUnlock()
+	return defaultScheme
+}
+
+// SetDefaultScheme overrides the shared runtime scheme. Once set, the scheme becomes frozen
+// and subsequent calls to EnsureDefaultScheme will not replace it. Passing a nil scheme is a no-op.
+func SetDefaultScheme(s *runtime.Scheme) {
+	if s == nil {
+		return
+	}
+	schemeMu.Lock()
+	defaultScheme = s
+	schemeFrozen = true
+	schemeMu.Unlock()
+}
+
+// EnsureDefaultScheme sets the shared runtime scheme only if it has not been customized yet.
+// This provides a first-one-wins behaviour that is useful when wiring a reconciler from a
+// controller-runtime manager. Passing a nil scheme is a no-op.
+func EnsureDefaultScheme(s *runtime.Scheme) {
+	if s == nil {
+		return
+	}
+	schemeMu.Lock()
+	if !schemeFrozen {
+		defaultScheme = s
+		schemeFrozen = true
+	}
+	schemeMu.Unlock()
+}
+
+// SelectScheme returns the first non-nil scheme from the provided list. If none are supplied,
+// it falls back to the shared default scheme.
+func SelectScheme(explicit ...*runtime.Scheme) *runtime.Scheme {
+	if len(explicit) > 0 && explicit[0] != nil {
+		return explicit[0]
+	}
+	return DefaultScheme()
+}

--- a/test/api/v1alpha1/example.com_tests.yaml
+++ b/test/api/v1alpha1/example.com_tests.yaml
@@ -58,8 +58,8 @@ spec:
                   of the Deployment.
                 properties:
                   availableReplicas:
-                    description: Total number of available pods (ready for at least
-                      minReadySeconds) targeted by this deployment.
+                    description: Total number of available non-terminating pods (ready
+                      for at least minReadySeconds) targeted by this deployment.
                     format: int32
                     type: integer
                   collisionCount:
@@ -112,13 +112,21 @@ spec:
                     format: int64
                     type: integer
                   readyReplicas:
-                    description: readyReplicas is the number of pods targeted by this
-                      Deployment with a Ready Condition.
+                    description: Total number of non-terminating pods targeted by
+                      this Deployment with a Ready Condition.
                     format: int32
                     type: integer
                   replicas:
-                    description: Total number of non-terminated pods targeted by this
-                      deployment (their labels match the selector).
+                    description: Total number of non-terminating pods targeted by
+                      this deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  terminatingReplicas:
+                    description: |-
+                      Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                      .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                      This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
                     format: int32
                     type: integer
                   unavailableReplicas:
@@ -129,8 +137,8 @@ spec:
                     format: int32
                     type: integer
                   updatedReplicas:
-                    description: Total number of non-terminated pods targeted by this
-                      deployment that have the desired template spec.
+                    description: Total number of non-terminating pods targeted by
+                      this deployment that have the desired template spec.
                     format: int32
                     type: integer
                 type: object

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/3scale-sre/basereconciler/reconciler"
+	"github.com/3scale-sre/basereconciler/runtimeconfig"
 	"github.com/goombaio/namegenerator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,6 +62,11 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Controller Suite")
 }
 
+func init() {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+	runtimeconfig.SetDefaultScheme(scheme.Scheme)
+}
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -80,10 +86,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
-
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme: runtimeconfig.DefaultScheme(),
 		// Disable the metrics port to allow running the
 		// test suite in parallel
 		Metrics: metricsserver.Options{BindAddress: "0"},


### PR DESCRIPTION
Introduce a concurrency-safe runtimeconfig package to own the shared runtime scheme, hook reconciler.NewFromManager into it, and update template constructors plus docs/tests to use the unified scheme API.

/kind feature
/priority important-soon
/assign